### PR TITLE
Add Stock field to Framework views and Product Requests

### DIFF
--- a/src/Http/Requests/CreateProduct.php
+++ b/src/Http/Requests/CreateProduct.php
@@ -28,6 +28,7 @@ class CreateProduct extends FormRequest implements CreateProductContract
             'sku'      => 'required|unique:products',
             'state'    => ['required', Rule::in(ProductStateProxy::values())],
             'price'    => 'nullable|numeric',
+            'stock'    => 'nullable|numeric',
             'images'   => 'nullable',
             'images.*' => 'image|mimes:jpeg,png,jpg,gif'
         ];

--- a/src/Http/Requests/UpdateProduct.php
+++ b/src/Http/Requests/UpdateProduct.php
@@ -32,6 +32,7 @@ class UpdateProduct extends FormRequest implements UpdateProductContract
                 ],
             'state'    => ['required', Rule::in(ProductStateProxy::values())],
             'price'    => 'nullable|numeric',
+            'stock'    => 'nullable|numeric',
             'images'   => 'nullable',
             'images.*' => 'image|mimes:jpeg,png,jpg,gif'
         ];

--- a/src/resources/views/product/_form.blade.php
+++ b/src/resources/views/product/_form.blade.php
@@ -38,6 +38,25 @@
 <div class="form-row">
     <div class="form-group col-12 col-md-6 col-xl-4">
         <div class="input-group">
+            <span class="input-group-addon">
+                <i class="zmdi zmdi-code-setting"></i>
+            </span>
+            {{ Form::text('stock', null, [
+                    'class' => 'form-control' . ($errors->has('stock') ? ' is-invalid' : ''),
+                    'placeholder' => __('Product Stock Count')
+                ])
+            }}
+        </div>
+        @if ($errors->has('stock'))
+            <input hidden class="form-control is-invalid">
+            <div class="invalid-feedback">{{ $errors->first('stock') }}</div>
+        @endif
+    </div>
+</div>
+
+<div class="form-row">
+    <div class="form-group col-12 col-md-6 col-xl-4">
+        <div class="input-group">
             {{ Form::text('price', null, [
                     'class' => 'form-control' . ($errors->has('price') ? ' is-invalid' : ''),
                     'placeholder' => __('Price')

--- a/src/resources/views/product/_form.blade.php
+++ b/src/resources/views/product/_form.blade.php
@@ -41,7 +41,7 @@
             <span class="input-group-addon">
                 <i class="zmdi zmdi-code-setting"></i>
             </span>
-            {{ Form::text('stock', null, [
+            {{ Form::number('stock', null, [
                     'class' => 'form-control' . ($errors->has('stock') ? ' is-invalid' : ''),
                     'placeholder' => __('Product Stock Count')
                 ])

--- a/tests/factories/ProductFactory.php
+++ b/tests/factories/ProductFactory.php
@@ -18,6 +18,7 @@ $factory->define(Product::class, function (Faker $faker) {
         'name'        => $faker->words(mt_rand(1, 3), true),
         'sku'         => $faker->unique()->ean8,
         'price'       => $faker->numberBetween(10, 2000),
+        'stock'       => $faker->numberBetween(10, 2000),
         'state'       => ProductState::ACTIVE,
         'description' => $faker->optional(0.9)->paragraph
     ];


### PR DESCRIPTION
Pull request updates framework product views to include Stock field that was added to product module here https://github.com/vanilophp/product/pull/5

Added Stock form field to the framework admin product _form.blade.php.
Added rule for stock to Requests/CreateProduct & Requests/UpdateProduct.
Added stock field to product factory. 