### PR TITLE
Make admin panel support image uploads for all models

### DIFF
--- a/src/Http/Controllers/MediaController.php
+++ b/src/Http/Controllers/MediaController.php
@@ -32,14 +32,8 @@ class MediaController extends BaseController
             return redirect()->back();
         }
 
-        // E.g. 'product'
-        $modelName = Str::singular(shorten(get_class($model)));
-
-        return redirect(route(
-            sprintf('vanilo.%s.edit', $modelName),
-            [$modelName => $model]
-            )
-        );
+        // redirect to the previous page
+        return redirect()->intended(url()->previous());
     }
 
     public function store(CreateMedia $request)

--- a/src/Http/Controllers/PropertyController.php
+++ b/src/Http/Controllers/PropertyController.php
@@ -38,7 +38,7 @@ class PropertyController extends BaseController
     public function store(CreateProperty $request)
     {
         try {
-            $property = PropertyProxy::create($request->all());
+            $property = PropertyProxy::create($request->except('images'));
             flash()->success(__(':name has been created', ['name' => $property->name]));
         } catch (\Exception $e) {
             flash()->error(__('Error: :msg', ['msg' => $e->getMessage()]));
@@ -65,7 +65,7 @@ class PropertyController extends BaseController
     public function update(Property $property, UpdateProperty $request)
     {
         try {
-            $property->update($request->all());
+            $property->update($request->except('images'));
 
             flash()->success(__(':name has been updated', ['name' => $property->name]));
         } catch (\Exception $e) {

--- a/src/Http/Controllers/PropertyController.php
+++ b/src/Http/Controllers/PropertyController.php
@@ -14,12 +14,15 @@ namespace Vanilo\Framework\Http\Controllers;
 use Konekt\AppShell\Http\Controllers\BaseController;
 use Vanilo\Framework\Contracts\Requests\CreateProperty;
 use Vanilo\Framework\Contracts\Requests\UpdateProperty;
+use Vanilo\Framework\Traits\CreateMediaTrait;
 use Vanilo\Properties\Contracts\Property;
 use Vanilo\Properties\Models\PropertyProxy;
 use Vanilo\Properties\PropertyTypes;
 
 class PropertyController extends BaseController
 {
+    use CreateMediaTrait;
+
     public function index()
     {
         return view('vanilo::property.index', [
@@ -40,6 +43,7 @@ class PropertyController extends BaseController
         try {
             $property = PropertyProxy::create($request->except('images'));
             flash()->success(__(':name has been created', ['name' => $property->name]));
+            $this->createMedia($property);
         } catch (\Exception $e) {
             flash()->error(__('Error: :msg', ['msg' => $e->getMessage()]));
 

--- a/src/Http/Controllers/PropertyValueController.php
+++ b/src/Http/Controllers/PropertyValueController.php
@@ -7,6 +7,7 @@ use Vanilo\Framework\Contracts\Requests\CreatePropertyValue;
 use Vanilo\Framework\Contracts\Requests\CreatePropertyValueForm;
 use Vanilo\Framework\Contracts\Requests\SyncModelPropertyValues;
 use Vanilo\Framework\Contracts\Requests\UpdatePropertyValue;
+use Vanilo\Framework\Traits\CreateMediaTrait;
 use Vanilo\Properties\Contracts\Property;
 use Vanilo\Properties\Contracts\PropertyValue;
 use Vanilo\Properties\Models\PropertyProxy;
@@ -14,6 +15,8 @@ use Vanilo\Properties\Models\PropertyValueProxy;
 
 class PropertyValueController extends BaseController
 {
+    use CreateMediaTrait;
+
     public function create(CreatePropertyValueForm $request, Property $property)
     {
         $propertyValue = app(PropertyValue::class);
@@ -44,6 +47,9 @@ class PropertyValueController extends BaseController
                 'title'    => $propertyValue->title,
                 'property' => $property->name
             ]));
+
+            $this->createMedia($propertyValue);
+
         } catch (\Exception $e) {
             flash()->error(__('Error: :msg', ['msg' => $e->getMessage()]));
 

--- a/src/Http/Controllers/PropertyValueController.php
+++ b/src/Http/Controllers/PropertyValueController.php
@@ -35,7 +35,7 @@ class PropertyValueController extends BaseController
         try {
             $propertyValue = PropertyValueProxy::create(
                 array_merge(
-                    $request->all(),
+                    $request->except('images'),
                     ['property_id' => $property->id]
                 )
             );
@@ -65,7 +65,7 @@ class PropertyValueController extends BaseController
     public function update(Property $property, PropertyValue $property_value, UpdatePropertyValue $request)
     {
         try {
-            $property_value->update($request->all());
+            $property_value->update($request->except('images'));
 
             flash()->success(__(':title has been updated', ['title' => $property_value->title]));
         } catch (\Exception $e) {

--- a/src/Http/Controllers/TaxonController.php
+++ b/src/Http/Controllers/TaxonController.php
@@ -44,7 +44,7 @@ class TaxonController extends BaseController
     public function store(Taxonomy $taxonomy, CreateTaxon $request)
     {
         try {
-            $taxon = TaxonProxy::create(array_merge($request->all(),
+            $taxon = TaxonProxy::create(array_merge($request->except('images'),
                 ['taxonomy_id' => $taxonomy->id]));
             flash()->success(__(':name :taxonomy has been created', [
                 'name'     => $taxon->name,
@@ -71,7 +71,7 @@ class TaxonController extends BaseController
     public function update(Taxonomy $taxonomy, Taxon $taxon, UpdateTaxon $request)
     {
         try {
-            $taxon->update($request->all());
+            $taxon->update($request->except('images'));
 
             flash()->success(__(':name has been updated', ['name' => $taxon->name]));
         } catch (\Exception $e) {

--- a/src/Http/Controllers/TaxonController.php
+++ b/src/Http/Controllers/TaxonController.php
@@ -19,9 +19,12 @@ use Vanilo\Category\Models\TaxonProxy;
 use Vanilo\Framework\Contracts\Requests\CreateTaxonForm;
 use Vanilo\Framework\Contracts\Requests\CreateTaxon;
 use Vanilo\Framework\Contracts\Requests\UpdateTaxon;
+use Vanilo\Framework\Traits\CreateMediaTrait;
 
 class TaxonController extends BaseController
 {
+    use CreateMediaTrait;
+
     public function create(CreateTaxonForm $request, Taxonomy $taxonomy)
     {
         $taxon = app(Taxon::class);
@@ -50,6 +53,7 @@ class TaxonController extends BaseController
                 'name'     => $taxon->name,
                 'taxonomy' => Str::singular($taxonomy->name)
             ]));
+            $this->createMedia($taxon);
         } catch (\Exception $e) {
             flash()->error(__('Error: :msg', ['msg' => $e->getMessage()]));
 

--- a/src/Http/Controllers/TaxonomyController.php
+++ b/src/Http/Controllers/TaxonomyController.php
@@ -17,9 +17,12 @@ use Vanilo\Category\Models\TaxonomyProxy;
 use Vanilo\Framework\Contracts\Requests\CreateTaxonomy;
 use Vanilo\Framework\Contracts\Requests\SyncModelTaxons;
 use Vanilo\Framework\Contracts\Requests\UpdateTaxonomy;
+use Vanilo\Framework\Traits\CreateMediaTrait;
 
 class TaxonomyController extends BaseController
 {
+    use CreateMediaTrait;
+
     public function index()
     {
         return view('vanilo::taxonomy.index', [
@@ -39,6 +42,7 @@ class TaxonomyController extends BaseController
         try {
             $taxonomy = TaxonomyProxy::create($request->except('images'));
             flash()->success(__(':name has been created', ['name' => $taxonomy->name]));
+            $this->createMedia($taxonomy);
         } catch (\Exception $e) {
             flash()->error(__('Error: :msg', ['msg' => $e->getMessage()]));
 

--- a/src/Http/Requests/CreateMedia.php
+++ b/src/Http/Requests/CreateMedia.php
@@ -19,7 +19,7 @@ class CreateMedia extends FormRequest implements CreateMediaContract
 {
     use HasFor;
 
-    protected $allowedFor = ['product'];
+    protected $allowedFor = ['product', 'property', 'taxonomy', 'taxon', 'property_value'];
 
     /**
      * @inheritDoc

--- a/src/Traits/CreateMediaTrait.php
+++ b/src/Traits/CreateMediaTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace Vanilo\Framework\Traits;
+
+
+trait CreateMediaTrait
+{
+    public function createMedia($model)
+    {
+        // Check if class uses MediaLibrary HasMediaTrait and the request has files
+        if (!empty(request()->files->filter('images')) && in_array(\Spatie\MediaLibrary\HasMedia\HasMediaTrait::class, class_uses(get_class($model)))) {
+            $model->addMultipleMediaFromRequest(['images'])->each(function ($fileAdder) {
+                $fileAdder->toMediaCollection();
+            });
+        }
+    }
+}


### PR DESCRIPTION
Adding images to models via MediaLibrary becomes a bit tedious since you have to override the admin controller for the model, to remove the images paramter from the request and add the media creation code (i used the same code from ProductController).

And also override the MediaController to adapt the return route for the destroy action, because routes like vanilo.property_value.edit requires 2 parameters not 1 as it is expected in MediaController.

I made a trait to reuse the media creation code, and added it to all controllers, i would add it to the BaseController but its not in this package.

So adding images to any models becomes easier as you just have to override the model and bind it with concord and override the forms and add the images field to edit and create pages, i just used the the partial views in product:

1. vanilo::product._create_images
2. vanilo::product._edit_images