### PR TITLE
Fix taxon vs taxa inflector bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.2",
         "laravel/framework": "~5.5|~6.0|~7.0",
-        "konekt/appshell": "~1.5",
+        "konekt/appshell": "~1.7",
         "spatie/laravel-medialibrary": "^7.3",
         "vanilo/contracts": "~1.2",
         "vanilo/support": "~1.2",

--- a/src/Providers/ModuleServiceProvider.php
+++ b/src/Providers/ModuleServiceProvider.php
@@ -13,6 +13,7 @@ namespace Vanilo\Framework\Providers;
 
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Konekt\Address\Contracts\Address as AddressContract;
+use Konekt\AppShell\Acl\ResourcePermissions;
 use Konekt\AppShell\Breadcrumbs\HasBreadcrumbs;
 use Konekt\Concord\BaseBoxServiceProvider;
 use Konekt\Customer\Contracts\Customer as CustomerContract;
@@ -76,6 +77,7 @@ class ModuleServiceProvider extends BaseBoxServiceProvider
     {
         parent::register();
 
+        ResourcePermissions::overrideResourcePlural('taxon', 'taxons');
         $this->app->bind(CheckoutDataFactoryContract::class, CheckoutDataFactory::class);
     }
 

--- a/src/resources/database/migrations/2020_05_24_204911_fix_accidental_taxa_named_permissions.php
+++ b/src/resources/database/migrations/2020_05_24_204911_fix_accidental_taxa_named_permissions.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-
 use Konekt\Acl\Models\PermissionProxy;
 
 /**

--- a/src/resources/database/migrations/2020_05_24_204911_fix_accidental_taxa_named_permissions.php
+++ b/src/resources/database/migrations/2020_05_24_204911_fix_accidental_taxa_named_permissions.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+use Konekt\Acl\Models\PermissionProxy;
+
+/**
+ * @see https://github.com/vanilophp/framework/issues/74
+ *
+ * This migration is to mitigate cases caused by Doctrine Inflector 1.4+
+ * where the plural of 'taxon' has been changed from 'taxons'->'taxa'
+ * When Vanilo migrations were ran with Inflector 1.4+, then these
+ * taxon related permissions were created with incorrect naming
+ * in the Database. If they're present, this SQL fixes them.
+ */
+class FixAccidentalTaxaNamedPermissions extends Migration
+{
+    /**
+     * This migration fixes accidental
+     */
+    public function up()
+    {
+        PermissionProxy::where(['name' => 'list taxa'])->update(['name' => 'list taxons']);
+        PermissionProxy::where(['name' => 'create taxa'])->update(['name' => 'create taxons']);
+        PermissionProxy::where(['name' => 'view taxa'])->update(['name' => 'view taxons']);
+        PermissionProxy::where(['name' => 'edit taxa'])->update(['name' => 'edit taxons']);
+        PermissionProxy::where(['name' => 'delete taxa'])->update(['name' => 'delete taxons']);
+    }
+
+    public function down()
+    {
+        // It's not going downwards since the original state is unknown/inconsistent
+    }
+}


### PR DESCRIPTION
This PR fixes Issue #74 by bumping minimal AppShell version to 1.7 and utilizing its feature to explicitly tell the plural version of the resource, in this case taxon -> taxons, instead of 'taxa'.

It also contains a migration that fixes permissions accidentally created with the name "taxa".

Even though taxa is the grammatically correct plural version of the word taxon, the "taxons" variant has been used for years now and using "taxa" breaks existing Vanilo installations.