### PR TITLE
Updated to laravel-medialibrary v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.4",
         "laravel/framework": "^6.18|^7.0|^8.0",
         "konekt/appshell": "^2.0",
-        "spatie/laravel-medialibrary": "^9.0",
+        "spatie/laravel-medialibrary": "^8.0|^9.0",
         "vanilo/contracts": "^2.0",
         "vanilo/support": "^2.0.1",
         "vanilo/category": "^2.0",
@@ -39,7 +39,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "~4.0|~5.0|~6.0",
-        "phpunit/phpunit" : "~8.0|~9.0",
+        "phpunit/phpunit": "~8.0|~9.0",
         "laravel/legacy-factories": "^1.0.4"
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.4",
         "laravel/framework": "^6.18|^7.0|^8.0",
         "konekt/appshell": "^2.0",
-        "spatie/laravel-medialibrary": "^8.0",
+        "spatie/laravel-medialibrary": "^9.0",
         "vanilo/contracts": "^2.0",
         "vanilo/support": "^2.0.1",
         "vanilo/category": "^2.0",

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -18,13 +18,13 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Vanilo\Category\Traits\HasTaxons;
 use Vanilo\Contracts\Buyable;
 use Vanilo\Properties\Traits\HasPropertyValues;
-use Vanilo\Support\Traits\BuyableImageSpatieV8;
+use Vanilo\Support\Traits\BuyableImageSpatieV9;
 use Vanilo\Support\Traits\BuyableModel;
 use Vanilo\Product\Models\Product as BaseProduct;
 
 class Product extends BaseProduct implements Buyable, HasMedia
 {
-    use BuyableModel, BuyableImageSpatieV8, InteractsWithMedia, HasTaxons, HasPropertyValues;
+    use BuyableModel, BuyableImageSpatieV9, InteractsWithMedia, HasTaxons, HasPropertyValues;
 
     protected const DEFAULT_THUMBNAIL_WIDTH  = 250;
     protected const DEFAULT_THUMBNAIL_HEIGHT = 250;

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -18,13 +18,13 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Vanilo\Category\Traits\HasTaxons;
 use Vanilo\Contracts\Buyable;
 use Vanilo\Properties\Traits\HasPropertyValues;
-use Vanilo\Support\Traits\BuyableImageSpatieV9;
+use Vanilo\Support\Traits\BuyableImageSpatieV8;
 use Vanilo\Support\Traits\BuyableModel;
 use Vanilo\Product\Models\Product as BaseProduct;
 
 class Product extends BaseProduct implements Buyable, HasMedia
 {
-    use BuyableModel, BuyableImageSpatieV9, InteractsWithMedia, HasTaxons, HasPropertyValues;
+    use BuyableModel, BuyableImageSpatieV8, InteractsWithMedia, HasTaxons, HasPropertyValues;
 
     protected const DEFAULT_THUMBNAIL_WIDTH  = 250;
     protected const DEFAULT_THUMBNAIL_HEIGHT = 250;

--- a/src/resources/database/migrations/2020_11_01_010500_upgrade_media_table_to_v9.php
+++ b/src/resources/database/migrations/2020_11_01_010500_upgrade_media_table_to_v9.php
@@ -15,7 +15,7 @@ class UpgradeMediaTableToV9 extends Migration
 
         DB::table('media')->cursor()->each(function ($media) {
             DB::table('media')->where('id', $media->id)->update([
-                'generated_conversions' => json_encode([])                                                       
+                'generated_conversions' => json_encode([])
             ]);
         });
 

--- a/src/resources/database/migrations/2020_11_01_010500_upgrade_media_table_to_v9.php
+++ b/src/resources/database/migrations/2020_11_01_010500_upgrade_media_table_to_v9.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpgradeMediaTableToV9 extends Migration
+{
+    public function up()
+    {
+        Schema::table('media', function (Blueprint $table) {
+            $table->json('generated_conversions')->nullable()->after('custom_properties');
+        });
+
+        DB::table('media')->cursor()->each(function ($media) {
+            DB::table('media')->where('id', $media->id)->update([
+                'generated_conversions' => json_encode([])                                                       
+            ]);
+        });
+
+        Schema::table('media', function (Blueprint $table) {
+            $table->json('generated_conversions')->nullable(false)->change();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('media', function (Blueprint $table) {
+            $table->dropColumn(['generated_conversions']);
+        });
+    }
+}


### PR DESCRIPTION
This adresses #92 and upgrade laravel-medialibrary to v9.
To be coherent with the previous laravel-medialibrary upgrades I also created a [pull request](https://github.com/vanilophp/support/pull/1) for the `vanilophp/support` package. 
It includes a migration for v9 and updates the frameworks `Product` model.

Both packages will need a dependency update. 