### PR TITLE
Fix: sku is not a CartItem attribute, but a Product attribute

### DIFF
--- a/src/resources/views/order/print/_items.blade.php
+++ b/src/resources/views/order/print/_items.blade.php
@@ -16,7 +16,7 @@
     @foreach($order->getItems() as $item)
         <tr>
             <td>{{ $loop->iteration }}</td>
-            <td>{{ $item->sku }}</td>
+            <td>{{ $item->product->sku }}</td>
             <td>{{ $item->name }}</td>
             <td>{{ $item->quantity }}</td>
             <td>{{ format_price($item->price) }}</td>


### PR DESCRIPTION
Fix print view: SKU is not a CartItem attribute, but a Product attribute.

PS: as an alternative fix, in CartItem.php model could be added as an accesor:

```
public function getSkuAttribute()
{
    return $this->product->sku;
}
```
