### PR TITLE
Fix PropertyValueController's FormRequest Errors #77 

### DIFF
--- a/src/Http/Controllers/PropertyValueController.php
+++ b/src/Http/Controllers/PropertyValueController.php
@@ -72,6 +72,9 @@ class PropertyValueController extends BaseController
         ]);
     }
 
+    /**
+     * @refactored 07-07-2021 sd@groundwow.com
+     */    
     public function update(Property $property, PropertyValue $property_value, UpdatePropertyValue $request)
     {
         try {

--- a/src/Http/Controllers/PropertyValueController.php
+++ b/src/Http/Controllers/PropertyValueController.php
@@ -35,12 +35,15 @@ class PropertyValueController extends BaseController
         ]);
     }
 
+    /**
+     * @refactored 07-07-2021 sd@groundwow.com
+     */
     public function store(Property $property, CreatePropertyValue $request)
     {
         try {
             $propertyValue = PropertyValueProxy::create(
                 array_merge(
-                    $request->except('images'),
+                    $request->validated(),
                     ['property_id' => $property->id]
                 )
             );

--- a/src/Http/Controllers/PropertyValueController.php
+++ b/src/Http/Controllers/PropertyValueController.php
@@ -75,7 +75,7 @@ class PropertyValueController extends BaseController
     public function update(Property $property, PropertyValue $property_value, UpdatePropertyValue $request)
     {
         try {
-            $property_value->update($request->except('images'));
+            $property_value->update($request->validated());
 
             flash()->success(__(':title has been updated', ['title' => $property_value->title]));
         } catch (\Exception $e) {

--- a/src/Http/Controllers/PropertyValueController.php
+++ b/src/Http/Controllers/PropertyValueController.php
@@ -68,7 +68,7 @@ class PropertyValueController extends BaseController
             'propertyValue' => $property_value
         ]);
     }
-  
+
     public function update(Property $property, PropertyValue $property_value, UpdatePropertyValue $request)
     {
         try {

--- a/src/Http/Controllers/PropertyValueController.php
+++ b/src/Http/Controllers/PropertyValueController.php
@@ -35,9 +35,6 @@ class PropertyValueController extends BaseController
         ]);
     }
 
-    /**
-     * @refactored 07-07-2021 sd@groundwow.com
-     */
     public function store(Property $property, CreatePropertyValue $request)
     {
         try {
@@ -71,10 +68,7 @@ class PropertyValueController extends BaseController
             'propertyValue' => $property_value
         ]);
     }
-
-    /**
-     * @refactored 07-07-2021 sd@groundwow.com
-     */    
+  
     public function update(Property $property, PropertyValue $property_value, UpdatePropertyValue $request)
     {
         try {

--- a/src/Http/Requests/CreatePropertyValue.php
+++ b/src/Http/Requests/CreatePropertyValue.php
@@ -20,7 +20,6 @@ class CreatePropertyValue extends FormRequest implements CreatePropertyValueCont
 {
     /**
      * @inheritDoc
-     * @refactored sd@groundwow.com 07-07-2021
      */
     public function rules()
     {

--- a/src/Http/Requests/CreatePropertyValue.php
+++ b/src/Http/Requests/CreatePropertyValue.php
@@ -20,13 +20,13 @@ class CreatePropertyValue extends FormRequest implements CreatePropertyValueCont
 {
     /**
      * @inheritDoc
+     * @refactored sd@groundwow.com 07-07-2021
      */
     public function rules()
     {
         return [
             'title' => 'required|min:1|max:255',
             'value' => 'nullable|min:1|max:255',
-            'property_id' => 'nullable|exists:properties,id',
             'priority' => 'nullable|integer'
         ];
     }

--- a/src/Http/Requests/UpdatePropertyValue.php
+++ b/src/Http/Requests/UpdatePropertyValue.php
@@ -20,7 +20,6 @@ class UpdatePropertyValue extends FormRequest implements UpdatePropertyValueCont
 {
     /**
      * @inheritDoc
-     * @refactored 07-07-2021 sd@groundwow.com
      */
     public function rules()
     {

--- a/src/Http/Requests/UpdatePropertyValue.php
+++ b/src/Http/Requests/UpdatePropertyValue.php
@@ -20,13 +20,14 @@ class UpdatePropertyValue extends FormRequest implements UpdatePropertyValueCont
 {
     /**
      * @inheritDoc
+     * @refactored 07-07-2021 sd@groundwow.com
      */
     public function rules()
     {
         return [
             'title' => 'required|min:1|max:255',
             'value' => 'nullable|min:1|max:255',
-            'property_id' => 'nullable|exists:properties,id',
+            'property_id' => 'required|exists:properties,id',
             'priority' => 'nullable|integer'
         ];
     }


### PR DESCRIPTION
PR for PropertyValueController's FormRequest Errors #77.

The styleci is failing not sure how to fix it.

Also not run tests so any guidance on how to do this would be amazing thank you.

Update::
I've created this change today as I currently have skipped a test I want to solve.

I've improved the general security of the PropertyValueController as they were creating models using $request->all().

https://www.youtube.com/watch?v=QQS5oEOguRU

https://laravel.com/docs/8.x/validation#creating-form-requests

```
    // Retrieve the validated input data...
    $validated = $request->validated();
```
Changed UpdatePropertyValue.php  to require property_id so no SQL error is visible to the user.
