### PR TITLE
round payment amount to 2 precision

### DIFF
--- a/src/Payment/Factories/PaymentFactory.php
+++ b/src/Payment/Factories/PaymentFactory.php
@@ -28,7 +28,7 @@ class PaymentFactory
         array $extraData = []
     ): Payment {
         $payment = PaymentProxy::create([
-            'amount' => $payable->getAmount(),
+            'amount' => round($payable->getAmount(), 2),
             'currency' => $payable->getCurrency(),
             'payable_type' => $payable->getPayableType(),
             'payable_id' => $payable->getPayableId(),


### PR DESCRIPTION
Changed the amount to ``` 'amount' => round($payable->getAmount(), 2),``` due to PayPal 2 precision error.