### PR TITLE
Change visibility of `ProductSearch` properties

### DIFF
--- a/src/Foundation/Search/ProductSearch.php
+++ b/src/Foundation/Search/ProductSearch.php
@@ -32,11 +32,11 @@ use Vanilo\Properties\Models\PropertyValueProxy;
 
 class ProductSearch
 {
-    private Searcher $searcher;
+    protected Searcher $searcher;
 
-    private Builder $productQuery;
+    protected Builder $productQuery;
 
-    private Builder $masterProductQuery;
+    protected Builder $masterProductQuery;
 
     public function __construct()
     {


### PR DESCRIPTION
Change visibility of `ProductSearch` properties from `private` to `proteced` to allow inheriting the class with access to this properties. It allows to add some project specific search/filter logic.
