### PR TITLE
Remove hard coded factory in `MasterProduct`

### DIFF
--- a/src/Foundation/Search/ProductSearch.php
+++ b/src/Foundation/Search/ProductSearch.php
@@ -21,7 +21,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Collection;
 use Konekt\Search\Facades\Search;
 use Konekt\Search\Searcher;
-use Vanilo\Foundation\Models\Taxon;
+use Vanilo\Category\Contracts\Taxon;
 use Vanilo\MasterProduct\Contracts\MasterProduct;
 use Vanilo\MasterProduct\Models\MasterProductProxy;
 use Vanilo\Product\Contracts\Product;
@@ -83,7 +83,7 @@ class ProductSearch
         return $this;
     }
 
-    public function orWithinTaxon(\Vanilo\Category\Contracts\Taxon $taxon): self
+    public function orWithinTaxon(Taxon $taxon): self
     {
         $this->productQuery->orWhereHas('taxons', function ($query) use ($taxon) {
             $query->where('id', $taxon->id);

--- a/src/MasterProduct/Models/MasterProduct.php
+++ b/src/MasterProduct/Models/MasterProduct.php
@@ -19,13 +19,11 @@ use Cviebrock\EloquentSluggable\Sluggable;
 use Cviebrock\EloquentSluggable\SluggableScopeHelpers;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Arr;
 use Konekt\Enum\Eloquent\CastsEnums;
 use Vanilo\MasterProduct\Contracts\MasterProduct as MasterProductContract;
-use Vanilo\MasterProduct\Tests\Factories\MasterProductFactory;
 use Vanilo\Product\Models\ProductState;
 use Vanilo\Product\Models\ProductStateProxy;
 
@@ -61,7 +59,7 @@ class MasterProduct extends Model implements MasterProductContract
     use CastsEnums;
     use Sluggable;
     use SluggableScopeHelpers;
-    use HasFactory;
+
 
     protected $guarded = ['id', 'created_at', 'updated_at'];
 
@@ -136,10 +134,5 @@ class MasterProduct extends Model implements MasterProductContract
                 'source' => 'name'
             ]
         ];
-    }
-
-    protected static function newFactory()
-    {
-        return MasterProductFactory::new();
     }
 }


### PR DESCRIPTION
I think it's not right to hard code the factory here. Over and beyond, the referenced factory class is not available.