### PR TITLE
Publish GitHub release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: release
+
+on:
+  push:
+    tags: ['*.*.*']
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Is this a prerelease?
+        run: |
+          PRERELEASE=false
+          # Check release type
+          if [[ $GITHUB_REF_NAME =~ 'alpha' || $GITHUB_REF_NAME =~ 'beta' || $GITHUB_REF_NAME =~ 'rc' ]]; then
+            echo "This is a prerelease."
+            PRERELEASE=true
+          fi
+          echo "is_prerelease=$PRERELEASE" >> $GITHUB_ENV
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: v${{ github.ref_name }}
+          body: Please refer to [Changelog.md](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/Changelog.md) for details.
+          draft: false
+          prerelease: ${{ env.is_prerelease }}


### PR DESCRIPTION
Following #159, this PR adds a GitHub Action to create a release on each tag push. 

You can find an example of how the release is rendered here: https://github.com/studiometa/framework/releases/tag/3.8.3.

If a tag containing `alpha`, `beta` or `rc` is pushed, the release will be marked as a prerelease.