### PR TITLE
Added sku filter method to `ProductSearch`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,7 +22,7 @@
 - Added the `Sale` and `SaleItem` interfaces to the contracts module
 - Changed the `Order` and `OrderItem` interfaces to extend the new `Sale` and `SaleItem` interfaces from the contracts module
 - Fixed issue where the `linkable` pointed to a missing product thus returning null
-- Added `notWithinSkus` method to `ProductSearch`
+- Added the `excludingSkus()` method to `ProductSearch`
 
 ## 4.x Series
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@
 - Added the `Sale` and `SaleItem` interfaces to the contracts module
 - Changed the `Order` and `OrderItem` interfaces to extend the new `Sale` and `SaleItem` interfaces from the contracts module
 - Fixed issue where the `linkable` pointed to a missing product thus returning null
+- Added `notWithinSkus` method to `ProductSearch`
 
 ## 4.x Series
 

--- a/src/Foundation/Search/ProductSearch.php
+++ b/src/Foundation/Search/ProductSearch.php
@@ -179,6 +179,14 @@ class ProductSearch
         return $this;
     }
 
+    public function notWithinSkus(array $skus): self
+    {
+        $this->productQuery->whereNotIn('sku', $skus);
+        $this->variantQuery?->whereNotIn('sku', $skus);
+
+        return $this;
+    }
+
     public function nameContains(string $term): self
     {
         $this->productQuery->where('name', 'like', "%$term%");

--- a/src/Foundation/Search/ProductSearch.php
+++ b/src/Foundation/Search/ProductSearch.php
@@ -179,7 +179,7 @@ class ProductSearch
         return $this;
     }
 
-    public function excludingSkus(string  ...$skus): self
+    public function excludingSkus(string ...$skus): self
     {
         $this->productQuery->whereNotIn('sku', $skus);
         $this->variantQuery?->whereNotIn('sku', $skus);

--- a/src/Foundation/Search/ProductSearch.php
+++ b/src/Foundation/Search/ProductSearch.php
@@ -179,7 +179,7 @@ class ProductSearch
         return $this;
     }
 
-    public function notWithinSkus(array $skus): self
+    public function excludingSkus(string  ...$skus): self
     {
         $this->productQuery->whereNotIn('sku', $skus);
         $this->variantQuery?->whereNotIn('sku', $skus);


### PR DESCRIPTION
Added a new method called `notWithinSkus` to the `ProductSearch`. It takes an `array` of SKUS as a parameter and removes them from the result. Applied to the `productQuery` and `variantQuery`.