### PR TITLE
Added the Translation Module

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 - Added ETA fields to Shipping Methods
 - Added the Order::inChannel() scope (Foundation)
 - Added the Video module
+- Added the Translation module
 - Added the `HasVideos` trait to the `Product`, `MasterProduct`, `MasterProductVariant`, `Taxon` and `Taxonomy` models in the Foundation module
 - Added the possibility to extend the `Features` helper
 - Added the `StaggeredDiscount` promotion action type

--- a/build-tools/split.sh
+++ b/build-tools/split.sh
@@ -40,6 +40,7 @@ remote properties
 remote shipment
 remote support
 remote taxes
+remote translation
 remote video
 
 split 'src/Adjustments' adjustments
@@ -58,4 +59,5 @@ split 'src/Properties' properties
 split 'src/Shipment' shipment
 split 'src/Support' support 8683e47dd2dbd15ac2ceac4dcfae405c4b271aff
 split 'src/Taxes' taxes
+split 'src/Translation' translation
 split 'src/Video' video

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
         },
         "files": [
             "src/Links/Support/helpers.php",
+            "src/Translation/Support/helpers.php",
             "src/Foundation/Support/helpers.php"
         ]
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -52,6 +52,12 @@
         <testsuite name="Taxes Tests">
             <directory>src/Taxes/Tests</directory>
         </testsuite>
+        <testsuite name="Videos Tests">
+            <directory>src/Video/Tests</directory>
+        </testsuite>
+        <testsuite name="Translations Tests">
+            <directory>src/Translation/Tests</directory>
+        </testsuite>
         <testsuite name="Foundation Tests">
             <directory>src/Foundation/Tests</directory>
         </testsuite>

--- a/src/Foundation/resources/config/box.php
+++ b/src/Foundation/resources/config/box.php
@@ -22,6 +22,7 @@ return [
         Vanilo\Taxes\Providers\ModuleServiceProvider::class => [],
         Vanilo\Promotion\Providers\ModuleServiceProvider::class => [],
         Vanilo\Video\Providers\ModuleServiceProvider::class => [],
+        Vanilo\Translation\Providers\ModuleServiceProvider::class => [],
     ],
     'event_listeners' => true,
     'image' => [

--- a/src/Translation/.gitattributes
+++ b/src/Translation/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto
+
+/.github export-ignore
+/Tests export-ignore
+.gitattributes export-ignore
+phpunit.xml export-ignore

--- a/src/Translation/.github/workflows/close-pull-request.yml
+++ b/src/Translation/.github/workflows/close-pull-request.yml
@@ -1,0 +1,13 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: superbrothers/close-pull-request@v3
+        with:
+          comment: "Thank you for your pull request. However, you have submitted this PR on a Vanilo sub-module which is a read-only split of `vanilo/framework`. Please submit your PR on the https://github.com/vanilophp/framework repository.<br><br>Thanks!"

--- a/src/Translation/.github/workflows/tests.yml
+++ b/src/Translation/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: tests
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        php: [ '8.3', '8.4' ]
+        laravel: [ '10.48', '11.0', '11.44', '12.0' ]
+    name: PHP ${{ matrix.php }} Laravel ${{ matrix.laravel }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Installing PHP
+        uses: shivammathur/setup-php@master
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, json, sqlite3
+          tools: composer:v2
+      - name: Lock Laravel Version
+        run: composer require "illuminate/support:${{ matrix.laravel }}.*" --no-update -v && composer require "illuminate/console:${{ matrix.laravel }}.*" --no-update -v
+      - name: Composer Install
+        run: composer install --prefer-dist --no-progress --no-interaction
+      - name: Run Tests
+        run: php vendor/bin/phpunit --testdox

--- a/src/Translation/Cache/StaticTranslationCache.php
+++ b/src/Translation/Cache/StaticTranslationCache.php
@@ -9,6 +9,7 @@ use Vanilo\Translation\Contracts\Translation;
 final class StaticTranslationCache
 {
     public const int DEFAULT_TTL = 15;
+
     private static array $cache = [];
 
     public static function exists(string $type, int|string $id, string $language): bool

--- a/src/Translation/Cache/StaticTranslationCache.php
+++ b/src/Translation/Cache/StaticTranslationCache.php
@@ -12,6 +12,11 @@ final class StaticTranslationCache
 
     private static array $cache = [];
 
+    public static function reset(): void
+    {
+        self::$cache = [];
+    }
+
     public static function exists(string $type, int|string $id, string $language): bool
     {
         return null !== self::get($type, $id, $language);

--- a/src/Translation/Cache/StaticTranslationCache.php
+++ b/src/Translation/Cache/StaticTranslationCache.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vanilo\Translation\Cache;
+
+use Vanilo\Translation\Contracts\Translation;
+
+final class StaticTranslationCache
+{
+    public const int DEFAULT_TTL = 15;
+    private static array $cache = [];
+
+    public static function exists(string $type, int|string $id, string $language): bool
+    {
+        return null !== self::get($type, $id, $language);
+    }
+
+    public static function get(string $type, int|string $id, string $language): ?Translation
+    {
+        if (null === $entry = self::$cache[self::key($type, $id, $language)] ?? null) {
+            return null;
+        }
+
+        if (is_int($entry['ttl']) && time() > $entry['ttl']) {
+            return null;
+        }
+
+        return $entry['value'];
+    }
+
+    public static function set(string $type, int|string $id, string $language, Translation $translation, int $ttl = self::DEFAULT_TTL): void
+    {
+        self::$cache[self::key($type, $id, $language)] = [
+            'value' => $translation,
+            'ttl' => $ttl < 0 ? null : time() + $ttl,
+        ];
+    }
+
+    private static function key(string $type, int|string $id, string $language): string
+    {
+        return "{$type}_{$id}_{$language}";
+    }
+}

--- a/src/Translation/Changelog.md
+++ b/src/Translation/Changelog.md
@@ -1,0 +1,8 @@
+# Vanilo Translation Module Changelog
+
+## 5.x Series
+
+## Unreleased
+##### 2025-XX-YY
+
+- Initial release of the module

--- a/src/Translation/Contracts/Translation.php
+++ b/src/Translation/Contracts/Translation.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vanilo\Translation\Contracts;
+
+use Illuminate\Database\Eloquent\Model;
+
+interface Translation
+{
+    public static function createForModel(Model $model, string $language, array $translatedAttributes): Translation;
+
+    public static function findByModel(Model $model, string $language): ?Translation;
+
+    public static function findBySlug(string $type, string $slug, string $language): ?Translation;
+
+    /** The two-letter ISO 639-1 code */
+    public function getLanguage(): string;
+
+    public function getName(): ?string;
+
+    public function getSlug(): ?string;
+
+    public function getTranslatedField(string $field): ?string;
+}

--- a/src/Translation/Contracts/Translation.php
+++ b/src/Translation/Contracts/Translation.php
@@ -14,6 +14,8 @@ interface Translation
 
     public static function findBySlug(string $type, string $slug, string $language): ?Translation;
 
+    public function getTranslatable(): Model;
+
     /** The two-letter ISO 639-1 code */
     public function getLanguage(): string;
 

--- a/src/Translation/LICENSE.md
+++ b/src/Translation/LICENSE.md
@@ -1,0 +1,21 @@
+# The MIT License (MIT)
+
+Copyright (c) 2025 Vanilo UG
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.

--- a/src/Translation/Models/Translation.php
+++ b/src/Translation/Models/Translation.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vanilo\Translation\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Vanilo\Translation\Contracts\Translation as TranslationContract;
+
+/**
+ * @property int $id
+ * @property string $language
+ * @property string $translatable_type
+ * @property int|string $translatable_id
+ * @property string|null $name
+ * @property string|null $slug
+ * @property array|null $fields
+ * @property bool $is_published
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ *
+ * @method static Translation create(array $attributes)
+ */
+class Translation extends Model implements TranslationContract
+{
+    protected $guarded = ['id', 'created_at', 'updated_at'];
+
+    protected $casts = [
+        'fields' => 'array',
+        'is_published' => 'bool',
+    ];
+
+    public static function findByModel(Model $model, string $language): ?TranslationContract
+    {
+        return static::query()
+            ->where('language', $language)
+            ->where('translatable_type', morph_type_of($model))
+            ->where('translatable_id', $model->getKey())
+            ->first();
+    }
+
+    public static function findBySlug(string $type, string $slug, string $language): ?TranslationContract
+    {
+        return static::query()
+            ->where('language', $language)
+            ->where('translatable_type', $type)
+            ->where('slug', $slug)
+            ->first();
+    }
+
+    public static function createForModel(Model $model, string $language, array $translatedAttributes): TranslationContract
+    {
+        return TranslationProxy::create([
+            'translatable_type' => morph_type_of($model),
+            'translatable_id' => $model->getKey(),
+            'language' => $language,
+            'name' => $translatedAttributes['name'] ?? null,
+            'slug' => $translatedAttributes['slug'] ?? null,
+            'fields' => Arr::except($translatedAttributes, ['name', 'slug']),
+        ]);
+    }
+
+    public function getLanguage(): string
+    {
+        return $this->language;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getSlug(): ?string
+    {
+        return $this->slug;
+    }
+
+    public function getTranslatedField(string $field): ?string
+    {
+        return match ($field) {
+            'name' => $this->getName(),
+            'slug' => $this->getSlug(),
+            default => is_array($this->fields) ? ($this->fields[$field] ?? null) : null,
+        };
+    }
+}

--- a/src/Translation/Models/Translation.php
+++ b/src/Translation/Models/Translation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vanilo\Translation\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Vanilo\Translation\Contracts\Translation as TranslationContract;
@@ -20,6 +21,8 @@ use Vanilo\Translation\Contracts\Translation as TranslationContract;
  * @property bool $is_published
  * @property Carbon $created_at
  * @property Carbon $updated_at
+ *
+ * @property-read Model $translatable
  *
  * @method static Translation create(array $attributes)
  */
@@ -60,6 +63,16 @@ class Translation extends Model implements TranslationContract
             'slug' => $translatedAttributes['slug'] ?? null,
             'fields' => Arr::except($translatedAttributes, ['name', 'slug']),
         ]);
+    }
+
+    public function translatable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function getTranslatable(): Model
+    {
+        return $this->translatable;
     }
 
     public function getLanguage(): string

--- a/src/Translation/Models/Translation.php
+++ b/src/Translation/Models/Translation.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Vanilo\Translation\Models;
 
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;

--- a/src/Translation/Models/TranslationProxy.php
+++ b/src/Translation/Models/TranslationProxy.php
@@ -4,8 +4,18 @@ declare(strict_types=1);
 
 namespace Vanilo\Translation\Models;
 
+use Illuminate\Database\Eloquent\Model;
 use Konekt\Concord\Proxies\ModelProxy;
 
+/**
+ * @method static \Vanilo\Translation\Contracts\Translation createForModel(Model $model, string $language, array $translatedAttributes)
+ * @method static \Vanilo\Translation\Contracts\Translation|null findByModel(Model $model, string $language)
+ * @method static \Vanilo\Translation\Contracts\Translation|null findBySlug(string $type, string $slug, string $language)
+ * @method string getLanguage()
+ * @method string|null getName()
+ * @method string|null getSlug()
+ * @method string|null getTranslatedField(string $field)
+ */
 class TranslationProxy extends ModelProxy
 {
 }

--- a/src/Translation/Models/TranslationProxy.php
+++ b/src/Translation/Models/TranslationProxy.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vanilo\Translation\Models;
+
+use Konekt\Concord\Proxies\ModelProxy;
+
+class TranslationProxy extends ModelProxy
+{
+}

--- a/src/Translation/Providers/ModuleServiceProvider.php
+++ b/src/Translation/Providers/ModuleServiceProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vanilo\Translation\Providers;
+
+use Konekt\Concord\BaseModuleServiceProvider;
+use Vanilo\Translation\Models\Translation;
+
+class ModuleServiceProvider extends BaseModuleServiceProvider
+{
+    protected $models = [
+        Translation::class,
+    ];
+}

--- a/src/Translation/README.md
+++ b/src/Translation/README.md
@@ -1,0 +1,21 @@
+# Vanilo Translation Module
+
+[![Tests](https://img.shields.io/github/actions/workflow/status/vanilophp/translation/tests.yml?branch=master&style=flat-square)](https://github.com/vanilophp/translation/actions?query=workflow%3Atests)
+[![Packagist version](https://img.shields.io/packagist/v/vanilo/translation.svg?style=flat-square)](https://packagist.org/packages/vanilo/translation)
+[![Packagist downloads](https://img.shields.io/packagist/dt/vanilo/translation.svg?style=flat-square)](https://packagist.org/packages/vanilo/translation)
+[![MIT Software License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE.md)
+
+This is the standalone Translation module from the [Vanilo E-commerce framework](https://vanilo.io)
+
+## Installation
+
+(As Standalone Component)
+
+1. `composer require vanilo/translation`
+2. `php artisan vendor:publish --provider="Konekt\Concord\ConcordServiceProvider"`
+3. Add `Vanilo\Translation\Providers\ModuleServiceProvider::class` to modules in `config/concord.php`
+4. `php artisan migrate`
+
+## Usage
+
+See the [Vanilo Translation Documentation](https://vanilo.io/docs/master/translation) for more details.

--- a/src/Translation/Support/helpers.php
+++ b/src/Translation/Support/helpers.php
@@ -8,7 +8,7 @@ use Vanilo\Translation\Contracts\Translation;
 use Vanilo\Translation\Models\TranslationProxy;
 
 if (!function_exists('_mt')) {
-    function _mt(Model $model, ?string $language = null, ?string $attribute = null): null|string|Translation
+    function _mt(Model $model, ?string $attribute = null, ?string $language = null): null|string|Translation
     {
         $language ??= app()->getLocale();
 

--- a/src/Translation/Support/helpers.php
+++ b/src/Translation/Support/helpers.php
@@ -3,13 +3,19 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Model;
+use Vanilo\Translation\Cache\StaticTranslationCache;
 use Vanilo\Translation\Contracts\Translation;
 use Vanilo\Translation\Models\TranslationProxy;
 
 if (!function_exists('_mt')) {
     function _mt(Model $model, ?string $language = null, ?string $attribute = null): null|string|Translation
     {
-        $translation = TranslationProxy::findByModel($model, $language ?? app()->getLocale());
+        if (null === $translation = StaticTranslationCache::get(morph_type_of($model), $model->getKey(), $language)) {
+            $translation = TranslationProxy::findByModel($model, $language ?? app()->getLocale());
+            if (null !== $translation) {
+                StaticTranslationCache::set(morph_type_of($model), $model->getKey(), $language, $translation);
+            }
+        }
 
         if (null === $attribute) {
             return $translation;

--- a/src/Translation/Support/helpers.php
+++ b/src/Translation/Support/helpers.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Model;
+use Vanilo\Translation\Contracts\Translation;
+use Vanilo\Translation\Models\TranslationProxy;
+
+if (!function_exists('_mt')) {
+    function _mt(Model $model, ?string $language = null, ?string $attribute = null): null|string|Translation
+    {
+        $translation = TranslationProxy::findByModel($model, $language ?? app()->getLocale());
+
+        if (null === $attribute) {
+            return $translation;
+        }
+
+        return $translation?->getTranslatedField($attribute);
+    }
+}

--- a/src/Translation/Support/helpers.php
+++ b/src/Translation/Support/helpers.php
@@ -10,11 +10,17 @@ use Vanilo\Translation\Models\TranslationProxy;
 if (!function_exists('_mt')) {
     function _mt(Model $model, ?string $language = null, ?string $attribute = null): null|string|Translation
     {
-        if (null === $translation = StaticTranslationCache::get(morph_type_of($model), $model->getKey(), $language)) {
-            $translation = TranslationProxy::findByModel($model, $language ?? app()->getLocale());
-            if (null !== $translation) {
-                StaticTranslationCache::set(morph_type_of($model), $model->getKey(), $language, $translation);
+        $language ??= app()->getLocale();
+
+        if (config('vanilo.translation.cache.enabled')) {
+            if (null === $translation = StaticTranslationCache::get(morph_type_of($model), $model->getKey(), $language)) {
+                $translation = TranslationProxy::findByModel($model, $language);
+                if (null !== $translation) {
+                    StaticTranslationCache::set(morph_type_of($model), $model->getKey(), $language, $translation);
+                }
             }
+        } else {
+            $translation = TranslationProxy::findByModel($model, $language);
         }
 
         if (null === $attribute) {

--- a/src/Translation/Tests/AAASmokeTest.php
+++ b/src/Translation/Tests/AAASmokeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vanilo\Translation\Tests;
+
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Test;
+
+class AAASmokeTest extends TestCase
+{
+    private const string MIN_PHP_VERSION = '8.3.0';
+
+    #[Test] public function smoke(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[Test] #[Depends('smoke')] public function php_version_satisfies_requirements(): void
+    {
+        $this->assertFalse(
+            version_compare(PHP_VERSION, self::MIN_PHP_VERSION, '<'),
+            'PHP version ' . self::MIN_PHP_VERSION . ' or greater is required but only '
+            . PHP_VERSION . ' found.'
+        );
+    }
+}

--- a/src/Translation/Tests/Examples/Product.php
+++ b/src/Translation/Tests/Examples/Product.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vanilo\Translation\Tests\Examples;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @method static Product create(array $attributes = [])
+ */
+class Product extends Model
+{
+
+    protected $table = 'products_translatable_test';
+
+    protected $guarded = ['id'];
+}

--- a/src/Translation/Tests/Examples/Product.php
+++ b/src/Translation/Tests/Examples/Product.php
@@ -11,7 +11,6 @@ use Illuminate\Database\Eloquent\Model;
  */
 class Product extends Model
 {
-
     protected $table = 'products_translatable_test';
 
     protected $guarded = ['id'];

--- a/src/Translation/Tests/MtHelperTest.php
+++ b/src/Translation/Tests/MtHelperTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vanilo\Translation\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use Vanilo\Translation\Models\Translation;
+use Vanilo\Translation\Tests\Examples\Product;
+
+class MtHelperTest extends TestCase
+{
+
+    #[Test] public function it_returns_translation_object_when_attribute_is_null()
+    {
+        $product = Product::create(['name' => 'Well', 'slug' => 'well']);
+        Translation::createForModel($product, 'hu', ['name' => 'Nos', 'slug' => 'nos']);
+
+        $translation = _mt($product, 'hu');
+
+        $this->assertInstanceOf(Translation::class, $translation);
+        $this->assertEquals('hu', $translation->getLanguage());
+        $this->assertEquals('Nos', $translation->getName());
+        $this->assertEquals('nos', $translation->getSlug());
+    }
+
+    #[Test] public function it_returns_translated_field_when_attribute_is_provided()
+    {
+        $product = Product::create(['name' => 'Fence', 'slug' => 'fence']);
+        Translation::createForModel($product, 'ro', ['name' => 'Grajd', 'slug' => 'grajd']);
+
+        $this->assertEquals('grajd', _mt($product, 'ro', 'slug'));
+    }
+
+    #[Test] public function it_uses_the_app_locale_when_language_is_not_provided()
+    {
+        $product = Product::create(['name' => 'Sneaker', 'slug' => 'sneaker']);
+        Translation::createForModel($product, 'fr', ['name' => 'Baskets', 'slug' => 'baskets']);
+        Translation::createForModel($product, 'cz', ['name' => 'Teniska', 'slug' => 'teniska']);
+
+        app()->setLocale('fr');
+        $translation = _mt($product);
+
+        $this->assertInstanceOf(Translation::class, $translation);
+        $this->assertEquals('fr', $translation->getLanguage());
+        $this->assertEquals('Baskets', $translation->getName());
+
+        app()->setLocale('cz');
+        $translation = _mt($product);
+
+        $this->assertInstanceOf(Translation::class, $translation);
+        $this->assertEquals('cz', $translation->getLanguage());
+        $this->assertEquals('Teniska', $translation->getName());
+    }
+
+    #[Test] public function it_returns_null_when_translation_not_found()
+    {
+        $product = Product::create(['name' => 'Screwdriver', 'slug' => 'screwdriver']);
+
+        $this->assertNull(_mt($product, 'cz', 'name'));
+        $this->assertNull(_mt($product, 'cz'));
+        $this->assertNull(_mt($product));
+    }
+
+    #[Test] public function it_returns_null_when_attribute_does_not_exist()
+    {
+        $product = Product::create(['name' => 'Kitchen', 'slug' => 'kitchen']);
+        Translation::createForModel($product, 'cz', ['name' => 'Kuchyně', 'slug' => 'kuchyne']);
+
+        $this->assertNull(_mt($product, 'cz', 'non_existent_field'));
+    }
+
+    #[Test] public function it_handles_empty_string_attribute_parameter()
+    {
+        $product = Product::create(['name' => 'Sink', 'slug' => 'sink']);
+
+        $this->assertNull(_mt($product, 'en', ''));
+    }
+}

--- a/src/Translation/Tests/MtHelperTest.php
+++ b/src/Translation/Tests/MtHelperTest.php
@@ -16,7 +16,7 @@ class MtHelperTest extends TestCase
         $product = Product::create(['name' => 'Well', 'slug' => 'well']);
         Translation::createForModel($product, 'hu', ['name' => 'Nos', 'slug' => 'nos']);
 
-        $translation = _mt($product, 'hu');
+        $translation = _mt($product, null, 'hu');
 
         $this->assertInstanceOf(Translation::class, $translation);
         $this->assertEquals('hu', $translation->getLanguage());
@@ -29,7 +29,7 @@ class MtHelperTest extends TestCase
         $product = Product::create(['name' => 'Fence', 'slug' => 'fence']);
         Translation::createForModel($product, 'ro', ['name' => 'Grajd', 'slug' => 'grajd']);
 
-        $this->assertEquals('grajd', _mt($product, 'ro', 'slug'));
+        $this->assertEquals('grajd', _mt($product, 'slug', 'ro'));
     }
 
     #[Test] public function it_uses_the_app_locale_when_language_is_not_provided()
@@ -57,8 +57,8 @@ class MtHelperTest extends TestCase
     {
         $product = Product::create(['name' => 'Screwdriver', 'slug' => 'screwdriver']);
 
-        $this->assertNull(_mt($product, 'cz', 'name'));
-        $this->assertNull(_mt($product, 'cz'));
+        $this->assertNull(_mt($product, 'name', 'cz'));
+        $this->assertNull(_mt($product, null, 'cz'));
         $this->assertNull(_mt($product));
     }
 
@@ -67,14 +67,14 @@ class MtHelperTest extends TestCase
         $product = Product::create(['name' => 'Kitchen', 'slug' => 'kitchen']);
         Translation::createForModel($product, 'cz', ['name' => 'Kuchyně', 'slug' => 'kuchyne']);
 
-        $this->assertNull(_mt($product, 'cz', 'non_existent_field'));
+        $this->assertNull(_mt($product, 'non_existent_field', 'cz'));
     }
 
     #[Test] public function it_handles_empty_string_attribute_parameter()
     {
         $product = Product::create(['name' => 'Sink', 'slug' => 'sink']);
 
-        $this->assertNull(_mt($product, 'en', ''));
+        $this->assertNull(_mt($product, '', 'en'));
     }
 
     #[Test] public function it_can_cache_the_translation_model_so_subsequent_calls_do_not_query_the_database()
@@ -87,11 +87,11 @@ class MtHelperTest extends TestCase
         \DB::enableQueryLog();
 
         // First call - should query the translation from the DB
-        $translation1 = _mt($product, 'es');
+        $translation1 = _mt($product, null, 'es');
         $queriesAfterFirstCall = count(\DB::getQueryLog());
 
         // Second call - should not touch the DB for the translation again
-        $translation2 = _mt($product, 'es');
+        $translation2 = _mt($product, null, 'es');
         $queriesAfterSecondCall = count(\DB::getQueryLog());
 
         $this->assertInstanceOf(Translation::class, $translation1);

--- a/src/Translation/Tests/MtHelperTest.php
+++ b/src/Translation/Tests/MtHelperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vanilo\Translation\Tests;
 
+use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\Test;
 use Vanilo\Translation\Models\Translation;
 use Vanilo\Translation\Tests\Examples\Product;
@@ -76,8 +77,10 @@ class MtHelperTest extends TestCase
         $this->assertNull(_mt($product, 'en', ''));
     }
 
-    #[Test] public function it_caches_the_translation_model_so_subsequent_calls_do_not_query_the_database()
+    #[Test] public function it_can_cache_the_translation_model_so_subsequent_calls_do_not_query_the_database()
     {
+        Config::set('vanilo.translation.cache.enabled', true);
+
         $product = Product::create(['name' => 'Table', 'slug' => 'table']);
         Translation::createForModel($product, 'es', ['name' => 'Mesa', 'slug' => 'mesa']);
 

--- a/src/Translation/Tests/MtHelperTest.php
+++ b/src/Translation/Tests/MtHelperTest.php
@@ -10,7 +10,6 @@ use Vanilo\Translation\Tests\Examples\Product;
 
 class MtHelperTest extends TestCase
 {
-
     #[Test] public function it_returns_translation_object_when_attribute_is_null()
     {
         $product = Product::create(['name' => 'Well', 'slug' => 'well']);

--- a/src/Translation/Tests/TestCase.php
+++ b/src/Translation/Tests/TestCase.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vanilo\Translation\Tests;
+
+use Illuminate\Foundation\Application;
+use Konekt\Concord\ConcordServiceProvider;
+use Orchestra\Testbench\TestCase as Orchestra;
+use Vanilo\Translation\Providers\ModuleServiceProvider as TranslationModule;
+
+abstract class TestCase extends Orchestra
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpDatabase($this->app);
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            ConcordServiceProvider::class
+        ];
+    }
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    protected function setUpDatabase(Application $app): void
+    {
+        $this->loadMigrationsFrom(__DIR__ . '/migrations');
+        \Artisan::call('migrate', ['--force' => true]);
+    }
+
+    protected function resolveApplicationConfiguration($app): void
+    {
+        parent::resolveApplicationConfiguration($app);
+
+        $app['config']->set('concord.modules', [
+            TranslationModule::class,
+        ]);
+    }
+}

--- a/src/Translation/Tests/TranslationTest.php
+++ b/src/Translation/Tests/TranslationTest.php
@@ -168,4 +168,16 @@ class TranslationTest extends TestCase
         $this->assertNull(Translation::findBySlug(morph_type_of($product), 'was-anderes', 'es'));
         $this->assertNull(Translation::findBySlug(morph_type_of($product), 'etwas-anderes', 'de'));
     }
+
+    #[Test] public function translation_has_a_reference_to_its_translatable_model()
+    {
+        $product = Product::create(['name' => 'Sigma Boy', 'slug' => 'sigma-boy']);
+        Translation::createForModel($product, 'ru', ['name' => 'Сигма Бой', 'slug' => 'sigma-boy']);
+
+        $translation = Translation::findByModel($product, 'ru');
+
+        $this->assertInstanceOf(Product::class, $translation->getTranslatable());
+        $this->assertSame($product->id, $translation->getTranslatable()->getKey());
+        $this->assertEquals('Сигма Бой', $translation->getName());
+    }
 }

--- a/src/Translation/Tests/TranslationTest.php
+++ b/src/Translation/Tests/TranslationTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vanilo\Translation\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use Vanilo\Translation\Models\Translation;
+use Vanilo\Translation\Tests\Examples\Product;
+
+class TranslationTest extends TestCase
+{
+    #[Test] public function it_can_be_created_with_minimal_data()
+    {
+        $translation = Translation::create([
+            'language' => 'en',
+            'translatable_type' => 'test_model',
+            'translatable_id' => 1
+        ]);
+
+        $this->assertEquals('en', $translation->language);
+        $this->assertEquals('test_model', $translation->translatable_type);
+        $this->assertEquals(1, $translation->translatable_id);
+    }
+
+    #[Test] public function it_can_be_created_with_all_fields()
+    {
+        $translation = Translation::create([
+            'language' => 'sa',
+            'translatable_type' => 'test_model',
+            'translatable_id' => 1,
+            'name' => 'परीक्षा नाम',
+            'slug' => 'parikshan-slag',
+            'is_published' => true,
+            'fields' => ['custom_field' => 'कस्टम क्षेत्र']
+        ])->fresh();
+
+        $this->assertEquals('sa', $translation->language);
+        $this->assertEquals('test_model', $translation->translatable_type);
+        $this->assertEquals(1, $translation->translatable_id);
+        $this->assertEquals('परीक्षा नाम', $translation->name);
+        $this->assertEquals('parikshan-slag', $translation->slug);
+        $this->assertTrue($translation->is_published);
+        $this->assertEquals(['custom_field' => 'कस्टम क्षेत्र'], $translation->fields);
+    }
+
+    #[Test] public function fields_can_be_nullable_except_required_ones()
+    {
+        $translation = Translation::create([
+            'language' => 'en',
+            'translatable_type' => 'test_model',
+            'translatable_id' => 1
+        ])->fresh();
+
+        $this->assertNull($translation->name);
+        $this->assertNull($translation->slug);
+        $this->assertTrue($translation->is_published);
+        $this->assertNull($translation->fields);
+    }
+
+    #[Test] public function get_translated_field_returns_value_from_fields_array()
+    {
+        $translation = Translation::create([
+            'language' => 'hu',
+            'translatable_type' => 'test_model',
+            'translatable_id' => 1,
+            'fields' => [
+                'description' => 'Teszt leírás',
+                'meta_title' => 'Teszt meta cím'
+            ]
+        ])->fresh();
+
+        $this->assertEquals('Teszt leírás', $translation->getTranslatedField('description'));
+        $this->assertEquals('Teszt meta cím', $translation->getTranslatedField('meta_title'));
+        $this->assertNull($translation->getTranslatedField('non_existent_field'));
+    }
+
+    #[Test] public function get_translated_field_returns_name_and_slug_fields()
+    {
+        $translation = Translation::create([
+            'language' => 'fi',
+            'translatable_type' => 'test_model',
+            'translatable_id' => 1,
+            'name' => 'Tuote',
+            'slug' => 'tuote',
+            'fields' => [
+                'description' => 'Test description'
+            ]
+        ])->fresh();
+
+        $this->assertEquals('Tuote', $translation->getTranslatedField('name'));
+        $this->assertEquals('tuote', $translation->getTranslatedField('slug'));
+    }
+
+    #[Test] public function get_translated_field_returns_null_when_field_not_in_fields_array()
+    {
+        $translation = Translation::create([
+            'language' => 'tt',
+            'translatable_type' => 'test_model',
+            'translatable_id' => 1,
+            'name' => 'Nameрнәк исем',
+            'slug' => 'үрнәк-исем',
+            'fields' => [
+                'description' => 'Тест тасвирламасы'
+            ]
+        ])->fresh();
+
+        $this->assertNull($translation->getTranslatedField('price'));
+        $this->assertNull($translation->getTranslatedField('color'));
+    }
+
+    #[Test] public function get_translated_field_returns_null_when_fields_is_null()
+    {
+        $translation = Translation::create([
+            'language' => 'en',
+            'translatable_type' => 'test_model',
+            'translatable_id' => 1,
+            'name' => 'Test Product',
+            'slug' => 'test-product',
+            'fields' => null
+        ])->fresh();
+
+        $this->assertNull($translation->getTranslatedField('description'));
+        $this->assertNull($translation->getTranslatedField('meta_title'));
+    }
+
+    #[Test] public function translation_can_be_found_by_model_and_language()
+    {
+        $product = Product::create(['name' => 'Something', 'slug' => 'something', 'description' => 'Nothing is easy, but who wants nothing?']);
+        Translation::createForModel($product, 'fr', ['name' => 'Quelque chose', 'slug' => 'quelque-chose', 'description' => 'Rien n’est facile, mais qui ne veut rien?']);
+
+        $translation = Translation::findByModel($product, 'fr');
+
+        $this->assertInstanceOf(Translation::class, $translation);
+        $this->assertEquals('fr', $translation->getLanguage());
+        $this->assertSame($product->id, $translation->translatable_id);
+        $this->assertEquals(morph_type_of($product), $translation->translatable_type);
+        $this->assertEquals('Quelque chose', $translation->getTranslatedField('name'));
+        $this->assertEquals('Quelque chose', $translation->getName());
+        $this->assertEquals('quelque-chose', $translation->getTranslatedField('slug'));
+        $this->assertEquals('quelque-chose', $translation->getSlug());
+        $this->assertEquals('Rien n’est facile, mais qui ne veut rien?', $translation->getTranslatedField('description'));
+    }
+
+    #[Test] public function find_by_model_returns_null_for_non_existent_translation()
+    {
+        $product = Product::create(['name' => 'This is a name', 'slug' => 'yes']);
+
+        $this->assertNull(Translation::findByModel($product, 'de'));
+    }
+
+    #[Test] public function translation_can_be_retrieved_by_slug()
+    {
+        $product = Product::create(['name' => 'What Else', 'slug' => 'what-else']);
+        Translation::createForModel($product, 'de', ['name' => 'Was anderes', 'slug' => 'was-anderes']);
+
+        $translation = Translation::findBySlug(morph_type_of($product), 'was-anderes', 'de');
+
+        $this->assertInstanceOf(Translation::class, $translation);
+        $this->assertEquals('de', $translation->getLanguage());
+        $this->assertSame($product->id, $translation->translatable_id);
+        $this->assertEquals(morph_type_of($product), $translation->translatable_type);
+        $this->assertEquals('Was anderes', $translation->getTranslatedField('name'));
+        $this->assertEquals('Was anderes', $translation->getName());
+        $this->assertEquals('was-anderes', $translation->getTranslatedField('slug'));
+        $this->assertEquals('was-anderes', $translation->getSlug());
+
+        $this->assertNull(Translation::findBySlug(morph_type_of($product), 'was-anderes', 'es'));
+        $this->assertNull(Translation::findBySlug(morph_type_of($product), 'etwas-anderes', 'de'));
+    }
+}

--- a/src/Translation/Tests/migrations/2025_04_23_142817_create_products_test_table.php
+++ b/src/Translation/Tests/migrations/2025_04_23_142817_create_products_test_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('products_translatable_test', static function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug');
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('products_translatable_test');
+    }
+};

--- a/src/Translation/composer.json
+++ b/src/Translation/composer.json
@@ -1,0 +1,31 @@
+{
+    "name": "vanilo/translation",
+    "description": "Vanilo Translation Module",
+    "type": "library",
+    "license": "MIT",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "keywords": ["translation", "i18n", "ecommerce", "vanilo", "laravel"],
+    "support": {
+        "issues": "https://github.com/vanilophp/framework/issues",
+        "source": "https://github.com/vanilophp/translation"
+    },
+    "require": {
+        "php": "^8.3",
+        "konekt/concord": "^1.15",
+        "konekt/xtend": "^2.0",
+        "laravel/framework": "^10.48|^11.0|^12.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.0|^11.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0"
+    },
+    "autoload": {
+        "psr-4": { "Vanilo\\Translation\\": "" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "5.0.x-dev"
+        }
+    }
+}

--- a/src/Translation/composer.json
+++ b/src/Translation/composer.json
@@ -21,7 +21,10 @@
         "orchestra/testbench": "^8.0|^9.0|^10.0"
     },
     "autoload": {
-        "psr-4": { "Vanilo\\Translation\\": "" }
+        "psr-4": { "Vanilo\\Translation\\": "" },
+        "files": [
+            "Support/helpers.php"
+        ]
     },
     "extra": {
         "branch-alias": {

--- a/src/Translation/phpunit.xml.dist
+++ b/src/Translation/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit colors="true" bootstrap="./vendor/autoload.php">
+    <testsuites>
+        <testsuite name="Vanilo Translation Module Test Suite">
+            <directory suffix="Test.php">./Tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Translation/resources/config/module.php
+++ b/src/Translation/resources/config/module.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'cache' => [
+        'enabled' => false,
+    ],
+];

--- a/src/Translation/resources/database/migrations/2025_04_23_141135_create_translations_table.php
+++ b/src/Translation/resources/database/migrations/2025_04_23_141135_create_translations_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('translations', static function (Blueprint $table) {
+            $table->id();
+            $table->morphs('translatable');
+            $table->char('language', 2)->comment('The two letter ISO 639-1 language code');
+            $table->string('name')->nullable();
+            $table->string('slug')->nullable();
+            $table->boolean('is_published')->default(true);
+            $table->json('fields')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('translations');
+    }
+};

--- a/src/Translation/resources/database/migrations/2025_04_23_141135_create_translations_table.php
+++ b/src/Translation/resources/database/migrations/2025_04_23_141135_create_translations_table.php
@@ -18,6 +18,9 @@ return new class () extends Migration {
             $table->boolean('is_published')->default(true);
             $table->json('fields')->nullable();
             $table->timestamps();
+
+            $table->unique(['translatable_type', 'translatable_id', 'language']);
+            $table->unique(['translatable_type', 'slug', 'language']);
         });
     }
 

--- a/src/Translation/resources/manifest.php
+++ b/src/Translation/resources/manifest.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'name' => 'Vanilo Translation Module',
+    'version' => '5.0-dev'
+];

--- a/src/Video/README.md
+++ b/src/Video/README.md
@@ -5,7 +5,7 @@
 [![Packagist downloads](https://img.shields.io/packagist/dt/vanilo/video.svg?style=flat-square)](https://packagist.org/packages/vanilo/video)
 [![MIT Software License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE.md)
 
-This is the standalone Taxes module from the [Vanilo E-commerce framework](https://vanilo.io)
+This is the standalone Video module from the [Vanilo E-commerce framework](https://vanilo.io)
 
 ## Installation
 


### PR DESCRIPTION
This PR contains the generic translation module with the interface, base model layer and the `_mt()` helper to be used in blade views.

### How to translate a model

```php
// Model to translate:
$product = Product::find(1);

// Create a French translation for the model:
Translation::createForModel($product, 'fr', [
    'name' => 'Quelque chose',
    'slug' => 'quelque-chose',
    'description' => 'Rien n’est facile, mais qui ne veut rien?'
]);
```

### How to use translations

```php
// Retrieve the French translation of the model:
$translation = Translation::findByModel($product, 'fr');

// Fields:
$translation->getLanguage();
// "fr"
// Get any field:
$translation->getTranslatedField('description')
// 'Rien n’est facile, mais qui ne veut rien?'
$translation->getTranslatedField('name')
// // 'Quelque chose'

// The `name` and `slug` fields are explicit, meaning you can retrieve them with a dedicated getter:

$translation->getName();
// 'Quelque chose'
$translation->getSlug()
// 'quelque-chose'
```

### Handling non-existent translations and fields

```php
Translation::findByModel($product, 'ee');
// null if no translation for the given model in the given language

$translation = Translation::findByModel($product, 'fr');
$translation->getTranslatedField('gtin');
// null - the field hasn't been translated
```

### Retrieving translations by slug instead of id/model

> [!TIP]
> Retrieving by slug can be useful in a controller to get the product by URL parameter

```php
$product = Product::create(['name' => 'What Else', 'slug' => 'what-else']);
Translation::createForModel($product, 'de', ['name' => 'Was anderes', 'slug' => 'was-anderes']);

$translation = Translation::findBySlug('product', 'was-anderes', 'de');

// If you aren't sure about the exact morph type name, use the helper function:
$translation = Translation::findBySlug(morph_type_of($product), 'was-anderes', 'de');

// To get the associated product:
$translation->getTranslatable();
// => The `Product` instance
```

### Blade Translation Helper

To make it simple to work with translated fields of a model, the `_mt($model, 'field')` helper is available:

```blade
<h1>{{ _mt($product, 'title') }}</h1>
<p>{{ _mt($product, 'description') }}</p>
```

This will retrieve the respective fields translated in the current locale based on `app()->getLocale()`.

If you explicitly want to tell which language to use for the translation, pass the language code as the 3rd parameter:

```blade
<h1>{{ _mt($product, 'title', 'es') }}</h1>
```

If the second parameter is null, then the entire `Translation` object is returned:

```php
_mt($product);
// => Translation object of the product in the current locale

_mt($product, null, 'cz');
// => The Czech Translation object of the product
```
