### PR TITLE
Sets helper function parameters explicitly nullable for PHP 8.4

### DIFF
--- a/src/Foundation/Support/helpers.php
+++ b/src/Foundation/Support/helpers.php
@@ -12,7 +12,7 @@ use Vanilo\MasterProduct\Contracts\MasterProductVariant;
  *
  * @return string
  */
-function format_price($price, string $currency = null)
+function format_price($price, ?string $currency = null)
 {
     $result = sprintf(
         config('vanilo.foundation.currency.format'),

--- a/src/Links/Support/helpers.php
+++ b/src/Links/Support/helpers.php
@@ -6,7 +6,7 @@ use Vanilo\Links\Models\LinkTypeProxy;
 use Vanilo\Links\Query\Get;
 
 if (!function_exists('links')) {
-    function links(string $type, string $property = null): Get
+    function links(string $type, ?string $property = null): Get
     {
         $result = Get::the($type)->links();
 
@@ -15,7 +15,7 @@ if (!function_exists('links')) {
 }
 
 if (!function_exists('link_items')) {
-    function link_items(string $type, string $property = null): Get
+    function link_items(string $type, ?string $property = null): Get
     {
         $result = Get::the($type)->linkItems();
 
@@ -24,7 +24,7 @@ if (!function_exists('link_items')) {
 }
 
 if (!function_exists('link_groups')) {
-    function link_groups(string $type, string $property = null): Get
+    function link_groups(string $type, ?string $property = null): Get
     {
         $result = Get::the($type)->groups();
 

--- a/src/Order/Models/Order.php
+++ b/src/Order/Models/Order.php
@@ -106,7 +106,7 @@ class Order extends Model implements OrderContract
         return $this->belongsTo(UserProxy::modelClass());
     }
 
-    public function getBillpayer(): ?BillPayer
+    public function getBillpayer(): ?Billpayer
     {
         return $this->billpayer;
     }


### PR DESCRIPTION
Updated `format_price`, `links`, `link_items`, and `link_groups` helper functions to use explicit nullable types to avoid deprecation warnings in PHP 8.4.

Also fixes a StyleCI failure.