### PR TITLE
Add Shipping Category Support to Product Models

### DIFF
--- a/src/Foundation/Models/MasterProduct.php
+++ b/src/Foundation/Models/MasterProduct.php
@@ -24,6 +24,7 @@ use Vanilo\Channel\Traits\Channelable;
 use Vanilo\Foundation\Traits\LoadsMediaConversionsFromConfig;
 use Vanilo\MasterProduct\Models\MasterProduct as BaseMasterProduct;
 use Vanilo\Properties\Traits\HasPropertyValues;
+use Vanilo\Shipment\Traits\BelongsToShippingCategory;
 use Vanilo\Support\Traits\HasImagesFromMediaLibrary;
 use Vanilo\Taxes\Traits\BelongsToTaxCategory;
 use Vanilo\Video\Traits\HasVideos;
@@ -35,6 +36,7 @@ use Vanilo\Video\Traits\HasVideos;
 class MasterProduct extends BaseMasterProduct implements HasMedia
 {
     use BelongsToTaxCategory;
+    use BelongsToShippingCategory;
     use Channelable;
     use InteractsWithMedia;
     use HasImagesFromMediaLibrary;

--- a/src/Foundation/Models/MasterProductVariant.php
+++ b/src/Foundation/Models/MasterProductVariant.php
@@ -57,13 +57,6 @@ class MasterProductVariant extends BaseMasterProductVariant implements Buyable, 
         return null !== $this->getRawOriginal('shipping_category_id');
     }
 
-    protected function shippingCategoryId(): Attribute
-    {
-        return Attribute::make(
-            get: fn ($value) => is_null($value) ? $this->masterProduct?->shipping_category_id : intval($value),
-        );
-    }
-
     public function shippingCategory(): BelongsTo
     {
         if ($this->hasOwnShippingCategory() || is_null($this->masterProduct)) {
@@ -76,5 +69,12 @@ class MasterProductVariant extends BaseMasterProductVariant implements Buyable, 
     public function getShippingCategory(): ?ShippingCategory
     {
         return $this->shippingCategory;
+    }
+
+    protected function shippingCategoryId(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => is_null($value) ? $this->masterProduct?->shipping_category_id : intval($value),
+        );
     }
 }

--- a/src/Foundation/Models/MasterProductVariant.php
+++ b/src/Foundation/Models/MasterProductVariant.php
@@ -69,8 +69,6 @@ class MasterProductVariant extends BaseMasterProductVariant implements Buyable, 
         if ($this->hasOwnShippingCategory() || is_null($this->masterProduct)) {
             return $this->belongsTo(ShippingCategoryProxy::modelClass());
         } else {
-            // This returns the relationship of another product, which is semantically incorrect, it is not what the
-            // client code assumes, thus can lead to problems.
             return $this->masterProduct->shippingCategory();
         }
     }

--- a/src/Foundation/Models/MasterProductVariant.php
+++ b/src/Foundation/Models/MasterProductVariant.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace Vanilo\Foundation\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -21,12 +23,20 @@ use Vanilo\Contracts\Buyable;
 use Vanilo\Foundation\Traits\LoadsMediaConversionsFromConfig;
 use Vanilo\MasterProduct\Models\MasterProductVariant as BaseMasterProductVariant;
 use Vanilo\Properties\Traits\HasPropertyValues;
+use Vanilo\Shipment\Contracts\ShippingCategory;
+use Vanilo\Shipment\Models\ShippingCategoryProxy;
 use Vanilo\Support\Traits\BuyableModel;
 use Vanilo\Support\Traits\HasImagesFromMediaLibrary;
 use Vanilo\Taxes\Contracts\Taxable;
 use Vanilo\Taxes\Traits\BelongsToTaxCategory;
 use Vanilo\Video\Traits\HasVideos;
 
+/**
+ *
+ * @property int|null $shipping_category_id
+ * @property-read \Vanilo\Shipment\Contracts\ShippingCategory|null $shippingCategory
+ *
+ */
 class MasterProductVariant extends BaseMasterProductVariant implements Buyable, HasMedia, Taxable
 {
     use BelongsToTaxCategory;
@@ -40,5 +50,33 @@ class MasterProductVariant extends BaseMasterProductVariant implements Buyable, 
     public function registerMediaConversions(Media $media = null): void
     {
         $this->loadConversionsFromVaniloConfig();
+    }
+
+    public function hasOwnShippingCategory(): bool
+    {
+        return null !== $this->getRawOriginal('shipping_category_id');
+    }
+
+    protected function shippingCategoryId(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => is_null($value) ? $this->masterProduct?->shipping_category_id : intval($value),
+        );
+    }
+
+    public function shippingCategory(): BelongsTo
+    {
+        if ($this->hasOwnShippingCategory() || is_null($this->masterProduct)) {
+            return $this->belongsTo(ShippingCategoryProxy::modelClass());
+        } else {
+            // This returns the relationship of another product, which is semantically incorrect, it is not what the
+            // client code assumes, thus can lead to problems.
+            return $this->masterProduct->shippingCategory();
+        }
+    }
+
+    public function getShippingCategory(): ?ShippingCategory
+    {
+        return $this->shippingCategory;
     }
 }

--- a/src/Foundation/Models/MasterProductVariant.php
+++ b/src/Foundation/Models/MasterProductVariant.php
@@ -59,7 +59,7 @@ class MasterProductVariant extends BaseMasterProductVariant implements Buyable, 
 
     public function shippingCategory(): BelongsTo
     {
-        if ($this->hasOwnShippingCategory() || is_null($this->masterProduct)) {
+        if ($this->hasOwnShippingCategory()) {
             return $this->belongsTo(ShippingCategoryProxy::modelClass());
         } else {
             return $this->masterProduct->shippingCategory();

--- a/src/Foundation/Models/Product.php
+++ b/src/Foundation/Models/Product.php
@@ -23,6 +23,7 @@ use Vanilo\Contracts\Buyable;
 use Vanilo\Foundation\Traits\LoadsMediaConversionsFromConfig;
 use Vanilo\Product\Models\Product as BaseProduct;
 use Vanilo\Properties\Traits\HasPropertyValues;
+use Vanilo\Shipment\Traits\BelongsToShippingCategory;
 use Vanilo\Support\Traits\BuyableModel;
 use Vanilo\Support\Traits\HasImagesFromMediaLibrary;
 use Vanilo\Taxes\Contracts\Taxable;
@@ -32,6 +33,7 @@ use Vanilo\Video\Traits\HasVideos;
 class Product extends BaseProduct implements Buyable, HasMedia, Taxable
 {
     use BelongsToTaxCategory;
+    use BelongsToShippingCategory;
     use BuyableModel;
     use Channelable;
     use InteractsWithMedia;

--- a/src/Foundation/Tests/ShippingCategoryTest.php
+++ b/src/Foundation/Tests/ShippingCategoryTest.php
@@ -145,6 +145,6 @@ class ShippingCategoryTest extends TestCase
             'master_product_id' => $masterProduct->id,
         ]);
 
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Relations\BelongsTo::class, $variant->shippingCategory());
+        $this->assertInstanceOf(Illuminate\Database\Eloquent\Relations\BelongsTo::class, $variant->shippingCategory());
     }
 }

--- a/src/Foundation/Tests/ShippingCategoryTest.php
+++ b/src/Foundation/Tests/ShippingCategoryTest.php
@@ -146,6 +146,6 @@ class ShippingCategoryTest extends TestCase
             'master_product_id' => $masterProduct->id,
         ]);
 
-        $this->assertInstanceOf(Illuminate\Database\Eloquent\Relations\BelongsTo::class, $variant->shippingCategory());
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Relations\BelongsTo::class, $variant->shippingCategory());
     }
 }

--- a/src/Foundation/Tests/ShippingCategoryTest.php
+++ b/src/Foundation/Tests/ShippingCategoryTest.php
@@ -2,10 +2,11 @@
 
 declare(strict_types=1);
 
+namespace Vanilo\Foundation\Tests;
+
 use Vanilo\Foundation\Models\MasterProduct;
 use Vanilo\Foundation\Models\MasterProductVariant;
 use Vanilo\Foundation\Models\Product;
-use Vanilo\Foundation\Tests\TestCase;
 use Vanilo\Shipment\Models\ShippingCategory;
 
 class ShippingCategoryTest extends TestCase

--- a/src/Foundation/Tests/ShippingCategoryTest.php
+++ b/src/Foundation/Tests/ShippingCategoryTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+use Vanilo\Foundation\Models\MasterProduct;
+use Vanilo\Foundation\Models\MasterProductVariant;
+use Vanilo\Foundation\Models\Product;
+use Vanilo\Foundation\Tests\TestCase;
+use Vanilo\Shipment\Models\ShippingCategory;
+
+class ShippingCategoryTest extends TestCase
+{
+    /** @test */
+    public function the_product_model_does_not_belong_to_a_shipping_category_by_default()
+    {
+        $product = factory(Product::class)->create([]);
+
+        $this->assertNull($product->shipping_category_id);
+        $this->assertNull($product->shippingCategory);
+        $this->assertNull($product->getShippingCategory());
+    }
+
+    /** @test */
+    public function the_master_product_model_does_not_belong_to_a_shipping_category_by_default()
+    {
+        $masterProduct = factory(MasterProduct::class)->create([]);
+
+        $this->assertNull($masterProduct->shipping_category_id);
+        $this->assertNull($masterProduct->shippingCategory);
+        $this->assertNull($masterProduct->getShippingCategory());
+    }
+
+    /** @test */
+    public function the_variant_model__does_not_belong_to_a_shipping_category_by_default()
+    {
+        $variant = factory(MasterProductVariant::class)->create([]);
+
+        $this->assertNull($variant->shipping_category_id);
+        $this->assertNull($variant->shippingCategory);
+        $this->assertNull($variant->getShippingCategory());
+    }
+
+    /** @test */
+    public function the_product_model_can_belong_to_a_shipping_category()
+    {
+        $shippingCategory = ShippingCategory::create(['name' => 'Standard']);
+        $product = factory(Product::class)->create([
+            'shipping_category_id' => $shippingCategory->id,
+        ]);
+
+        $this->assertInstanceOf(ShippingCategory::class, $product->shippingCategory);
+        $this->assertEquals($shippingCategory->id, $product->shipping_category_id);
+        $this->assertEquals($shippingCategory->id, $product->shippingCategory->id);
+        $this->assertEquals($shippingCategory->id, $product->getShippingCategory()->id);
+    }
+
+    /** @test */
+    public function the_master_product_model_can_belong_to_a_shipping_category()
+    {
+        $shippingCategory = ShippingCategory::create(['name' => 'Standard']);
+        $masterProduct = factory(MasterProduct::class)->create([
+            'shipping_category_id' => $shippingCategory->id,
+        ]);
+
+        $this->assertInstanceOf(ShippingCategory::class, $masterProduct->shippingCategory);
+        $this->assertEquals($shippingCategory->id, $masterProduct->shipping_category_id);
+        $this->assertEquals($shippingCategory->id, $masterProduct->shippingCategory->id);
+        $this->assertEquals($shippingCategory->id, $masterProduct->getShippingCategory()->id);
+    }
+
+    /** @test */
+    public function the_variant_model_can_belong_to_a_shipping_category()
+    {
+        $shippingCategory = ShippingCategory::create(['name' => 'Standard']);
+        $variant = factory(MasterProductVariant::class)->create([
+            'shipping_category_id' => $shippingCategory->id,
+        ]);
+
+        $this->assertInstanceOf(ShippingCategory::class, $variant->shippingCategory);
+        $this->assertEquals($shippingCategory->id, $variant->shipping_category_id);
+        $this->assertEquals($shippingCategory->id, $variant->shippingCategory->id);
+        $this->assertEquals($shippingCategory->id, $variant->getShippingCategory()->id);
+    }
+
+    /** @test */
+    public function the_variant_model_shadows_the_master_products_shipping_category()
+    {
+        $masterShippingCategory = ShippingCategory::create(['name' => 'Master Shipping Category']);
+        $variantShippingCategory = ShippingCategory::create(['name' => 'Variant Shipping Category']);
+        $masterProduct = factory(MasterProduct::class)->create([
+            'shipping_category_id' => $masterShippingCategory->id,
+        ]);
+        $variant = factory(MasterProductVariant::class)->create([
+            'master_product_id' => $masterProduct->id,
+            'shipping_category_id' => $variantShippingCategory->id,
+        ]);
+
+        $this->assertInstanceOf(ShippingCategory::class, $variant->shippingCategory);
+        $this->assertTrue($variant->hasOwnShippingCategory());
+        $this->assertEquals($variantShippingCategory->id, $variant->shipping_category_id);
+        $this->assertEquals($variantShippingCategory->id, $variant->shippingCategory->id);
+        $this->assertEquals($variantShippingCategory->id, $variant->getShippingCategory()->id);
+    }
+
+    /** @test */
+    public function the_variant_model_uses_the_master_products_shipping_category_if_it_doest_specify_one_of_his_own()
+    {
+        $masterShippingCategory = ShippingCategory::create(['name' => 'Master Shipping Category']);
+        $masterProduct = factory(MasterProduct::class)->create([
+            'shipping_category_id' => $masterShippingCategory->id,
+        ]);
+        $variant = factory(MasterProductVariant::class)->create([
+            'master_product_id' => $masterProduct->id,
+        ]);
+
+        $this->assertInstanceOf(ShippingCategory::class, $variant->shippingCategory);
+        $this->assertFalse($variant->hasOwnShippingCategory());
+        $this->assertEquals($masterShippingCategory->id, $variant->shipping_category_id);
+        $this->assertEquals($masterShippingCategory->id, $variant->shippingCategory->id);
+        $this->assertEquals($masterShippingCategory->id, $variant->getShippingCategory()->id);
+    }
+
+    /** @test */
+    public function the_variant_model_has_no_shipping_category_if_it_has_none_of_his_own_and_master_has_none()
+    {
+        $masterProduct = factory(MasterProduct::class)->create([]);
+        $variant = factory(MasterProductVariant::class)->create([
+            'master_product_id' => $masterProduct->id,
+        ]);
+
+        $this->assertNull($variant->shipping_category_id);
+        $this->assertFalse($variant->hasOwnShippingCategory());
+        $this->assertNull($variant->shippingCategory);
+        $this->assertNull($variant->getShippingCategory());
+    }
+
+    /** @test */
+    public function the_variant_model_returns_the_masters_belongs_to_relationship_if_it_doesnt_specify_its_own_shipping_category()
+    {
+        $masterShippingCategory = ShippingCategory::create(['name' => 'Master Shipping Category']);
+        $masterProduct = factory(MasterProduct::class)->create([
+            'shipping_category_id' => $masterShippingCategory->id,
+        ]);
+        $variant = factory(MasterProductVariant::class)->create([
+            'master_product_id' => $masterProduct->id,
+        ]);
+
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Relations\BelongsTo::class, $variant->shippingCategory());
+    }
+}

--- a/src/Foundation/resources/database/migrations/2025_06_23_101504_add_shipping_category_id_to_products.php
+++ b/src/Foundation/resources/database/migrations/2025_06_23_101504_add_shipping_category_id_to_products.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->bigInteger('shipping_category_id')->unsigned()->nullable();
+        });
+        Schema::table('master_products', function (Blueprint $table) {
+            $table->bigInteger('shipping_category_id')->unsigned()->nullable();
+        });
+        Schema::table('master_product_variants', function (Blueprint $table) {
+            $table->bigInteger('shipping_category_id')->unsigned()->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('shipping_category_id');
+        });
+        Schema::table('master_products', function (Blueprint $table) {
+            $table->dropColumn('shipping_category_id');
+        });
+        Schema::table('master_product_variants', function (Blueprint $table) {
+            $table->dropColumn('shipping_category_id');
+        });
+    }
+};

--- a/src/Shipment/Tests/ModuleTest.php
+++ b/src/Shipment/Tests/ModuleTest.php
@@ -13,7 +13,6 @@ use Vanilo\Shipment\Models\Shipment;
 use Vanilo\Shipment\Models\ShippingCategory;
 use Vanilo\Shipment\Models\ShippingMethod;
 use Vanilo\Shipment\Providers\ModuleServiceProvider;
-use Vanilo\Shipment\Tests\TestCase;
 
 class ModuleTest extends TestCase
 {

--- a/src/Shipment/Tests/ModuleTest.php
+++ b/src/Shipment/Tests/ModuleTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Vanilo\Shipment\Tests;
+
 use Vanilo\Shipment\Contracts\Carrier as CarrierContract;
 use Vanilo\Shipment\Contracts\Shipment as ShipmentContract;
 use Vanilo\Shipment\Contracts\ShippingCategory as ShippingCategoryContract;

--- a/src/Shipment/Tests/ShippingCategoryTest.php
+++ b/src/Shipment/Tests/ShippingCategoryTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Vanilo\Shipment\Tests;
+
 use Vanilo\Shipment\Contracts\ShippingCategory as ShippingCategoryContract;
 use Vanilo\Shipment\Models\ShippingCategory;
 use Vanilo\Shipment\Models\ShippingCategoryProxy;

--- a/src/Shipment/Tests/ShippingCategoryTest.php
+++ b/src/Shipment/Tests/ShippingCategoryTest.php
@@ -7,7 +7,6 @@ namespace Vanilo\Shipment\Tests;
 use Vanilo\Shipment\Contracts\ShippingCategory as ShippingCategoryContract;
 use Vanilo\Shipment\Models\ShippingCategory;
 use Vanilo\Shipment\Models\ShippingCategoryProxy;
-use Vanilo\Shipment\Tests\TestCase;
 
 class ShippingCategoryTest extends TestCase
 {


### PR DESCRIPTION
- Added shipping category support for `Product`, `MasterProduct` and `MasterProductVariant` in the `Foundation` namespace
- Make `MasterProductVariant` "inherit" the shipping category of its Master Product if it doesn't specify one of its own

_Note:_  I wonder if returning the `BelongsTo` relationship of the Master Product from within the Variant (when the Variant does not has its own shipping category) can cause any problems/confusion in the client code?