### PR TITLE
Subitem Copy Support to the Order Factory

### DIFF
--- a/src/Foundation/Factories/OrderFactory.php
+++ b/src/Foundation/Factories/OrderFactory.php
@@ -73,12 +73,22 @@ class OrderFactory extends BaseOrderFactory
     protected function convertCartItemsToDataArray(CheckoutSubject $cart)
     {
         return $cart->getItems()->map(function ($item) {
-            return [
+            $result = [
                 'product' => $item->getBuyable(),
                 'quantity' => $item->getQuantity(),
                 'configuration' => $item instanceof Configurable ? $item->configuration() : null,
                 'adjustments' => $item instanceof Adjustable ? $item->adjustments() : [],
             ];
+
+            if (isset($item->id)) {
+                $result['id'] = $item->id;
+            }
+
+            if (isset($item->parent_id)) {
+                $result['parent_id'] = $item->parent_id;
+            }
+
+            return $result;
         })->all();
     }
 }

--- a/src/Foundation/Tests/ExtendedOrderFactoryTest.php
+++ b/src/Foundation/Tests/ExtendedOrderFactoryTest.php
@@ -40,8 +40,7 @@ class ExtendedOrderFactoryTest extends TestCase
         );
     }
 
-    /** @test */
-    public function it_copies_the_shipping_adjustment_over_from_the_cart_to_the_order()
+    #[Test] public function it_copies_the_shipping_adjustment_over_from_the_cart_to_the_order()
     {
         $product = factory(Product::class)->create(['price' => 25]);
         $shippingMethod = ShippingMethod::create([


### PR DESCRIPTION
- Order module: mapped the source item's parent child relationship to the created order items. Used the `id` and `parent_id` properties of the source item array to achieve this, constructed a mapping from the source item to the order item to be able to map the parent-child relationship.
- Passed the `id` and `parent_id`  of a cart item in the Foundation module for the mapping to be effective